### PR TITLE
CARRY: Configure Kueue Pod webhooks so they do not interfere with infra Pods

### DIFF
--- a/config/components/webhook/kustomization.yaml
+++ b/config/components/webhook/kustomization.yaml
@@ -4,3 +4,33 @@ resources:
 
 configurations:
 - kustomizeconfig.yaml
+
+patches:
+- patch: |-
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: MutatingWebhookConfiguration
+    metadata:
+      name: mutating-webhook-configuration
+    webhooks:
+    - name: mpod.kb.io
+      namespaceSelector:
+        matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - kueue-system
+- patch: |-
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      name: validating-webhook-configuration
+    webhooks:
+    - name: vpod.kb.io
+      namespaceSelector:
+        matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - kube-system
+          - kueue-system

--- a/config/components/webhook/manifests.yaml
+++ b/config/components/webhook/manifests.yaml
@@ -162,6 +162,25 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /mutate--v1-pod
+  failurePolicy: Fail
+  name: mpod.kb.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /mutate-ray-io-v1-raycluster
   failurePolicy: Fail
   name: mraycluster.kb.io
@@ -417,6 +436,26 @@ webhooks:
     - UPDATE
     resources:
     - mpijobs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate--v1-pod
+  failurePolicy: Fail
+  name: vpod.kb.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
   sideEffects: None
 - admissionReviewVersions:
   - v1

--- a/config/rhoai/kustomization.yaml
+++ b/config/rhoai/kustomization.yaml
@@ -44,3 +44,5 @@ patches:
 - path: manager_webhook_patch.yaml
 - path: manager_metrics_patch.yaml
 - path: auth_proxy_service_patch.yaml
+- path: mutating_webhook_patch.yaml
+- path: validating_webhook_patch.yaml

--- a/config/rhoai/mutating_webhook_patch.yaml
+++ b/config/rhoai/mutating_webhook_patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+  - $patch: delete
+    name: mpod.kb.io

--- a/config/rhoai/validating_webhook_patch.yaml
+++ b/config/rhoai/validating_webhook_patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+  - $patch: delete
+    name: vpod.kb.io


### PR DESCRIPTION
### Issue Link

fixes https://issues.redhat.com/browse/RHOAIENG-2123


### What this PR does / why we need it:

This pr updates to the Kueue deployment, specifically targeting the validation and mutating admission webhooks. By default, Kueue's webhooks operate on Pod resources, which can inadvertently affect critical infrastructure components, such as CNI plugins. To prevent potential interference the pr adds a patch,removing the webhooks.

This pr also re-adds the original patches in config/components/webhook/kustomizaiton.yaml to avoid future rebase conflicts from the kueue repository.

Adding a standard patch with and empty webhook field [], would not suffice, and therefor [ `$patch: delete` ](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/inlinePatch.md)was used. 

### Testing the changes:

Without the patch applied: 
Ensure you deployment directory in the makefile is set to `config/rhoai`
run `make manifests` and ` IMAGE_REGISTRY=<your-image-registry> make image-local-push deploy`.

Here, some operations will present the interference, such as running 'kubectl apply -f examples/admin/single-clusterqueue-setup.yaml' will result in the following: 

```
localqueue.kueue.x-k8s.io/user-queue created
Error from server (InternalError): error when creating "examples/admin/single-clusterqueue-setup.yaml": Internal error occurred: failed calling webhook "mresourceflavor.kb.io": failed to call webhook: Post "https://kueue-webhook-service.kueue-system.svc:443/mutate-kueue-x-k8s-io-v1beta1-resourceflavor?timeout=10s": no endpoints available for service "kueue-webhook-service"
Error from server (InternalError): error when creating "examples/admin/single-clusterqueue-setup.yaml": Internal error occurred: failed calling webhook "mclusterqueue.kb.io": failed to call webhook: Post "https://kueue-webhook-service.kueue-system.svc:443/mutate-kueue-x-k8s-io-v1beta1-clusterqueue?timeout=10s": no endpoints available for service "kueue-webhook-service"
```
Notice `kueue-validating-webhook-configuraiton` will have 16 webhooks, and `kueue-mutating-webhook-configuration will have 14.

Now reapply the patches, and follow the same steps ensuring conflicts no longer arise.

Check the `kueue-validating-webhook-configuration` and `kueue-mutating-webhook-configuration` and ensure they contain the updated configuration, without the  vpod.kb.io and mpod.kb.io webhooks.

`kueue-validating-webhook-configuraiton` will now have 15 webhooks whilst `kueue-mutating-webhook-configuration will have 13.

