### PR TITLE
PATCH: Rebase on Kueue v0.6.0

### DIFF
--- a/config/rhoai/params.env
+++ b/config/rhoai/params.env
@@ -1,1 +1,1 @@
-odh-kueue-controller-image=gcr.io/k8s-staging-kueue/kueue:main
+odh-kueue-controller-image=registry.k8s.io/kueue/kueue:v0.6.0


### PR DESCRIPTION
Rebased on Kueue v0.6.0 and set the default container image accordingly. 