### PR TITLE
PATCH: Change function to wait until the admission check is properly removed

### DIFF
--- a/test/e2e/singlecluster/e2e_test.go
+++ b/test/e2e/singlecluster/e2e_test.go
@@ -357,7 +357,7 @@ var _ = ginkgo.Describe("Kueue", func() {
 			gomega.Expect(util.DeleteAllJobsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
 			util.ExpectClusterQueueToBeDeleted(ctx, k8sClient, clusterQueue, true)
 			util.ExpectResourceFlavorToBeDeleted(ctx, k8sClient, onDemandRF, true)
-			gomega.Expect(k8sClient.Delete(ctx, check)).Should(gomega.Succeed())
+			util.ExpectAdmissionCheckToBeDeleted(ctx, k8sClient, check, true)
 		})
 
 		ginkgo.It("Should unsuspend a job only after all checks are cleared", func() {


### PR DESCRIPTION
Test in singlecluster/e2etest.go fails in openshift CI Job as it takes time to remove admission check and hence 
changing function to wait until the admission check is properly removed