### PR TITLE
CARRY: Allow non-admin user access to view clusterqueue (metrics)

### DIFF
--- a/config/rhoai/batch-user-rolebinding.yaml
+++ b/config/rhoai/batch-user-rolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: batch-user-rolebinding
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:authenticated'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: batch-user-role

--- a/config/rhoai/clusterqueue_viewer_role_patch.yaml
+++ b/config/rhoai/clusterqueue_viewer_role_patch.yaml
@@ -1,0 +1,7 @@
+# patch to add clusterqueue-viewer-role to batch-user
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: clusterqueue-viewer-role
+  labels:
+    rbac.kueue.x-k8s.io/batch-user: 'true'

--- a/config/rhoai/kustomization.yaml
+++ b/config/rhoai/kustomization.yaml
@@ -41,6 +41,7 @@ resources:
 - monitor.yaml
 - binding_admin_roles.yaml
 - webhook_network_policy.yaml
+- batch-user-rolebinding.yaml
 
 patches:
 # Mount the controller config file for loading manager configurations
@@ -51,3 +52,4 @@ patches:
 - path: auth_proxy_service_patch.yaml
 - path: mutating_webhook_patch.yaml
 - path: validating_webhook_patch.yaml
+- path: clusterqueue_viewer_role_patch.yaml


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds configuration that will allow a non-admin user (as part of the system:authenticated group)  to view clusterqueue and clusterqueue/status. This change is in relation to work on a DW metrics dashboard UI - [Related Feature](https://issues.redhat.com/browse/RHOAISTRAT-44).

#### Which issue(s) this PR fixes:

Fixes # https://issues.redhat.com/browse/RHOAIENG-3754 

#### Verification Steps
This has been verified manually on the DW-Dashboard cluster which has the Workload Metrics UI deployed. Further work in the UI side is required in order for kueue metrics to be accessed there.