### PR TITLE
Added support for s390x and ppc64le for multi-arch image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ GINKGO_VERSION ?= $(shell $(GO_CMD) list -m -f '{{.Version}}' github.com/onsi/gi
 
 GIT_TAG ?= $(shell git describe --tags --dirty --always)
 # Image URL to use all building/pushing image targets
-PLATFORMS ?= linux/amd64,linux/arm64
+PLATFORMS ?= linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
 DOCKER_BUILDX_CMD ?= docker buildx
 IMAGE_BUILD_CMD ?= $(DOCKER_BUILDX_CMD) build
 IMAGE_BUILD_EXTRA_OPTS ?=


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
Feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR will add the support for s390x and ppc64le for multi-arch image build
#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:
We have successfully created multi-arch images and pushed into local image registry. We have successfully deployed the created images on Openshift platform runs on s390x architecture. We have also shared screenshots for the same.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
<img width="1777" alt="Screenshot 2024-04-05 at 5 33 44 PM" src="https://github.com/opendatahub-io/kueue/assets/97394641/c9c58b60-9885-4b7b-a6e9-0c11bcd1c05c">
<img width="678" alt="image" src="https://github.com/opendatahub-io/kueue/assets/97394641/2188123b-fecf-4a29-ab42-b20e2bef83cc">
<img width="473" alt="image" src="https://github.com/opendatahub-io/kueue/assets/97394641/0930cd83-7d12-4bc1-a11b-d93adb2fcdf1">


