### PR TITLE
Add enableIngress validation check in RayCluster webhook

### DIFF
--- a/pkg/controller/jobs/raycluster/raycluster_webhook.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook.go
@@ -95,10 +95,13 @@ func (w *RayClusterWebhook) ValidateCreate(ctx context.Context, obj runtime.Obje
 func (w *RayClusterWebhook) validateCreate(job *rayv1.RayCluster) field.ErrorList {
 	var allErrors field.ErrorList
 	kueueJob := (*RayCluster)(job)
+	specPath := field.NewPath("spec")
+	if job.Spec.HeadGroupSpec.EnableIngress == nil || *job.Spec.HeadGroupSpec.EnableIngress {
+		allErrors = append(allErrors, field.Invalid(specPath.Child("headGroupSpec").Child("enableIngress"), job.Spec.HeadGroupSpec.EnableIngress, "creating RayCluster resources with EnableIngress set to true or unspecified is not allowed"))
+	}
 
 	if w.manageJobsWithoutQueueName || jobframework.QueueName(kueueJob) != "" {
 		spec := &job.Spec
-		specPath := field.NewPath("spec")
 
 		// TODO revisit once Support dynamically sized (elastic) jobs #77 is implemented
 		// Should not use auto scaler. Once the resources are reserved by queue the cluster should do it's best to use them.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->


## What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

## What this PR does / why we need it:
This PR adds validation to check if the RayCluster headGroupSpec contains the `enableIngress` field OR if it is set to `true`, and if conditions are met, the webhook will forbid the creation of the RayCluster resource.

Acceptance criteria:

- As a data scientist, I cannot create a RayCluster resource with EnableIngress set to true
- As a data scientist, I cannot create a RayCluster resource when EnableIngress is not specified
- As a data scientist, I can create a Ray cluster via the CodeFlare SDK

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Jira: https://issues.redhat.com/browse/RHOAIENG-5116 

## Special notes for your reviewer:
Verification Steps:
1. Login to your OpenShift cluster.
2. Run KubeRay v1.1.0 - [This could work](https://docs.ray.io/en/master/cluster/kubernetes/getting-started/raycluster-quick-start.html#:~:text=kindest/node%3Av1.26.0-,Step%202%3A%20Deploy%20a%20KubeRay%20operator,-%23)
3. Run the CFO locally against the cluster with `make run NAMESPACE=somenamespace`
4. Run Kueue - To test this change:
    - You would need to build and push a new Kueue image i.e., : 
    ```
    IMAGE_REGISTRY=quay.io/yourusername make image-local-push
    ```
    - Make that new quay repository `public`.
    - Then replace the [params.env](https://github.com/opendatahub-io/kueue/blob/dev/config/rhoai/params.env) file with your new image i.e.: `quay.io/yourusername/kueue:v0.6.0-rhoai-2.9-tests-1-gdb3e81af-dirty`
    - Deploy Kueue with `kubectl apply --server-side -k config/rhoai`
5. Create `ClusterQueue`, `LocalQueue`, and `ResourceFlavor` if not done already.
6. Install the SDK from this PR: https://github.com/project-codeflare/codeflare-sdk/pull/506
7. Attempt to create a RayCluster in a notebook with:
```
cluster = Cluster(ClusterConfiguration(
    name='jobtest',
    namespace='default', # or localqueue namespace
    num_workers=1,
    min_cpus=1,
    max_cpus=1,
    min_memory=2,
    max_memory=2,
    num_gpus=0,
    write_to_file=True,
    image="quay.io/project-codeflare/ray:latest-py39-cu118"
))
```
8. In terminal, you could try `vi .codeflare/resources/jobtest.yaml` and modify `enableIngress` field under headGroupSpec to be True/False or remove the field entirely.
9. If `enableIngress` is not False, the RayCluster will not be created.

## Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The user will not be allowed to create RayCluster resource if the enableIngress field is true or unset.
```