### PR TITLE
CARRY: Adding info level alerts

### DIFF
--- a/config/components/manager/controller_manager_config.yaml
+++ b/config/components/manager/controller_manager_config.yaml
@@ -4,7 +4,7 @@ health:
   healthProbeBindAddress: :8081
 metrics:
   bindAddress: :8080
-# enableClusterQueueResources: true
+  enableClusterQueueResources: true
 webhook:
   port: 9443
 leaderElection:

--- a/config/rhoai/kustomization.yaml
+++ b/config/rhoai/kustomization.yaml
@@ -43,6 +43,7 @@ resources:
 - webhook_network_policy.yaml
 - batch-user-rolebinding.yaml
 - kueue-metrics-service.yaml
+- prometheus_rule.yaml
 
 patches:
 # Mount the controller config file for loading manager configurations

--- a/config/rhoai/prometheus_rule.yaml
+++ b/config/rhoai/prometheus_rule.yaml
@@ -1,0 +1,44 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: prometheus-rules
+  namespace: openshift-monitoring
+spec:
+  groups:
+    - name: kueue-critical-alerts
+      rules:
+      - alert: KueuePodDown
+        expr: kube_pod_status_ready{pod=~"kueue-.*", condition="true"} == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Kueue pod is down ({{ $labels.pod }})"
+          description: "The Kueue pod {{ $labels.pod }} in namespace {{ $labels.namespace }} is not ready."
+    - name: kueue-info-alerts
+      rules:
+      - alert: LowClusterQueueResourceUsage
+        expr: sum(kueue_cluster_queue_resource_usage) by (cluster_queue, resource) / sum(kueue_cluster_queue_nominal_quota) by (cluster_queue, resource) < 0.2
+        for: 1d
+        labels:
+          severity: info
+        annotations:
+          summary: Low {{ $labels.resource }} resource usage in cluster queue {{ $labels.cluster_queue }}
+          description: The {{ $labels.resource }} resource usage in cluster queue {{ $labels.cluster_queue }} is below 20% of its nominal quota for more than 1 day.
+      - alert: ResourceReservationExceedsQuota
+        expr: (sum(kueue_cluster_queue_resource_reservation) by (resource, cluster_queue)) / 10 > (sum(kueue_cluster_queue_nominal_quota) by (resource, cluster_queue))
+        for: 10m
+        labels:
+          severity: info
+        annotations:
+          summary: Resource {{ $labels.resource }} reservation far exceeds the available quota in cluster queue {{ $labels.cluster_queue}}
+          description: Resource {{ $labels.resource }} reservation is 10 times the available quota in cluster queue {{ $labels.cluster_queue}}
+      - alert: PendingWorkloadPods
+        expr: (sum by (namespace, pod) (sum_over_time(kube_pod_status_phase{phase="Pending"}[3d])) >= 3 * 24 * 60) >0
+        for: 1m
+        labels:
+          severity: info
+        annotations:
+          summary: Pod {{ $labels.pod }} in the {{ $labels.namespace }} namespace has been pending for more than 3 days
+          description: A pod {{ $labels.pod }} in the {{ $labels.namespace }} namespace has been in the pending state for more than 3 days.
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds info level alerts around resource usage and requests. 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Resolves #[RHOAIENG-1251](https://issues.redhat.com/browse/RHOAIENG-1251)

#### Special notes for your reviewer:
To test the alerts:
* apply the prometheus_rule.yaml file to an openshift cluster. 
* Then restart the prometheus-operator pod.
* You can then navigate to the Observe menu on the left side of the screen and choose Alerting. The alerts should be viewable under the alerting rules tab. If any alerts are firing they are viewable under the Alerts tab also.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```