### PR TITLE
CARRY: Add .snyk file to ignore cmd/kueuectl and test directories from snyk scans

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,6 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities
+version: v1.25.0
+exclude:
+  global:
+    - cmd/kueuectl/**
+    - test/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added a [.snyk file ](https://docs.snyk.io/manage-risk/policies/the-.snyk-file#how-to-create-the-.snyk-file) to ignore the `cmd/kueuectl` and `test` directories from "Snyk code analysis".

I've enabled an option through the Snyk UI to exclude these directories, but they can only be excluded for "dependency analysis". There isn't an option in the UI to exclude from "code analysis" but can be achieved by using the `.snyk` file.

The need for this is that we are getting false positives on CVEs on files from the `cmd/kueuectl` directory which are not used in production. This can be seen here: https://app.snyk.io/org/red-hat-openshift-data-science-rhods/project/0a4fb1d3-5fb2-4dfc-a480-1e9524091370

Moreover, Jiras are being created through automation:
https://issues.redhat.com/browse/RHOAIENG-10506

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. With [snyk cli](https://docs.snyk.io/snyk-cli/install-or-update-the-snyk-cli) installed, run `snyk code test` on main branch of this repo and see CVEs.
2. Add the .snyk file and run `snyk code test` and see no CVEs.