### PR TITLE
Add VAP manifests to a dedicated folder

### DIFF
--- a/config/rhoai/ocp-4.17-addons/validating_admission_policy.yaml
+++ b/config/rhoai/ocp-4.17-addons/validating_admission_policy.yaml
@@ -1,0 +1,20 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: kueue-validating-admission-policy
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["ray.io"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["rayclusters"]
+  matchConditions:
+    - name: "skip-if-deleting"
+      expression: "!has(object.metadata.deletionTimestamp)"
+    - name: "skip-if-owned-by-appwrapper"
+      expression: "!has(object.metadata.ownerReferences) || object.metadata.ownerReferences.exists(ref, ref.kind != 'AppWrapper')"
+  validations:
+    - expression: "has(object.metadata.labels) && 'kueue.x-k8s.io/queue-name' in object.metadata.labels && object.metadata.labels['kueue.x-k8s.io/queue-name'] != ''"
+      message: "The label 'kueue.x-k8s.io/queue-name' is either missing or does not have a value set."

--- a/config/rhoai/ocp-4.17-addons/validating_admission_policy_binding.yaml
+++ b/config/rhoai/ocp-4.17-addons/validating_admission_policy_binding.yaml
@@ -1,0 +1,9 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: kueue-validating-admission-policy-binding
+spec:
+  policyName: kueue-validating-admission-policy
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector: {} # Match all namespaces


### PR DESCRIPTION
Part of: https://issues.redhat.com/browse/RHOAIENG-14731 

This dedicated folder captures all ocp-4.17+ manifests to be applied. This folder will be used by the RHOAI Operator to apply the resources based on the OCP version that it is installed on: https://issues.redhat.com/browse/RHOAIENG-16133 

Tests for this feature will follow in the [distributed-workloads](https://github.com/opendatahub-io/distributed-workloads) repository.


## How to test this?
You could manually apply the manifests, then attempt:
- Create a RayCluster without a LocalQueue label, which will be rejected by the VAP resource.
- Create a RayCluster with a LocalQueue label, which should be admitted.
- Create an AppWrapper with or without the LocalQueue label, this resource should be admitted.