### PR TITLE
[CARRY] take arg for builder image so it can be overwritten in CI

### DIFF
--- a/Dockerfile.rhoai
+++ b/Dockerfile.rhoai
@@ -1,5 +1,6 @@
+ARG GOLANG_IMAGE=registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.22.2
 # Start of Go versioning workaround for lack of go-toolset for version 1.22
-FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.22.2 AS golang
+FROM ${GOLANG_IMAGE} AS golang
 
 FROM registry.access.redhat.com/ubi9/ubi:latest AS builder
 


### PR DESCRIPTION
I was making changes to the OpenShift CI releases repo but the build was erroring out because
```
registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.22.2
```
couldn't be pulled. I've turned the image into an arg so that it can be overwritten by the OpenShift CI build