### PR TITLE
RHOAIENG-17826: Fix metrics ports after deprecation of kube-rbac-proxy

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -19,4 +19,4 @@ spec:
         ports:
         - containerPort: 8443
           protocol: TCP
-          name: https
+          name: metrics

--- a/config/default/metrics_service.yaml
+++ b/config/default/metrics_service.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: system
 spec:
   ports:
-    - name: https
+    - name: metrics
       port: 8443
       protocol: TCP
       targetPort: 8443

--- a/config/rhoai/kueue-metrics-service.yaml
+++ b/config/rhoai/kueue-metrics-service.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   ports:
   - name: metrics
-    port: 8080
+    port: 8443
     protocol: TCP
     targetPort: metrics
   selector:

--- a/config/rhoai/manager_metrics_patch.yaml
+++ b/config/rhoai/manager_metrics_patch.yaml
@@ -9,6 +9,6 @@ spec:
       containers:
       - name: manager
         ports:
-        - containerPort: 8080
+        - containerPort: 8443
           protocol: TCP
           name: metrics

--- a/config/rhoai/monitor.yaml
+++ b/config/rhoai/monitor.yaml
@@ -1,6 +1,6 @@
 # Prometheus Pod Monitor (Metrics)
 apiVersion: monitoring.coreos.com/v1
-kind: PodMonitor
+kind: ServiceMonitor
 metadata:
   name: controller-manager-metrics-monitor
   namespace: system
@@ -9,5 +9,9 @@ spec:
     matchLabels:
       app.kubernetes.io/name: kueue
       app.kubernetes.io/component: controller
-  podMetricsEndpoints:
-    - port: metrics
+  endpoints:
+  - port: metrics
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:
Fix metrics ports after deprecation of kube-rbac-proxy

#### Which issue(s) this PR fixes:
Fixes [RHOAIENG-17826](https://issues.redhat.com//browse/RHOAIENG-17826)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```