### PR TITLE
RHOAIENG-18674: Rename metrics port to https-metrics to allow upgrade by operator

### DIFF
--- a/config/rhoai/kueue-metrics-service.yaml
+++ b/config/rhoai/kueue-metrics-service.yaml
@@ -4,10 +4,10 @@ metadata:
   name: metrics-service
 spec:
   ports:
-  - name: metrics
+  - name: https-metrics
     port: 8443
     protocol: TCP
-    targetPort: metrics
+    targetPort: https-metrics
   selector:
     app.kubernetes.io/name: kueue
     app.kubernetes.io/part-of: kueue

--- a/config/rhoai/manager_metrics_patch.yaml
+++ b/config/rhoai/manager_metrics_patch.yaml
@@ -9,6 +9,6 @@ spec:
       containers:
       - name: manager
         ports:
-        - containerPort: 8443
+        - containerPort: 8080
           protocol: TCP
           name: metrics

--- a/config/rhoai/manager_webhook_patch.yaml
+++ b/config/rhoai/manager_webhook_patch.yaml
@@ -12,6 +12,9 @@ spec:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
+        - containerPort: 8443
+          protocol: TCP
+          name: https-metrics
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert

--- a/config/rhoai/monitor.yaml
+++ b/config/rhoai/monitor.yaml
@@ -10,7 +10,7 @@ spec:
       app.kubernetes.io/name: kueue
       app.kubernetes.io/component: controller
   endpoints:
-  - port: metrics
+  - port: https-metrics
     scheme: https
     tlsConfig:
       insecureSkipVerify: true


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHOAIENG-18674
Renames metrics port to https-metrics to allow upgrade by operator