### PR TITLE
CARRY: use authorization in ServiceMonitor to scrape metrics

### DIFF
--- a/config/rhoai/kueue-metrics-service.yaml
+++ b/config/rhoai/kueue-metrics-service.yaml
@@ -10,6 +10,5 @@ spec:
     targetPort: https-metrics
   selector:
     app.kubernetes.io/name: kueue
-    app.kubernetes.io/part-of: kueue
 status:
   loadBalancer: {}

--- a/config/rhoai/kueue_metrics_reader_secret.yaml
+++ b/config/rhoai/kueue_metrics_reader_secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: controller-manager-metrics-reader
+  labels:
+    app.kubernetes.io/name: kueue
+    app.kubernetes.io/component: controller
+  name: controller-manager-metrics-token
+  namespace: system
+type: kubernetes.io/service-account-token

--- a/config/rhoai/kueue_metrics_reader_serviceaccount.yaml
+++ b/config/rhoai/kueue_metrics_reader_serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: kueue
+    app.kubernetes.io/component: controller
+  namespace: system
+  name: controller-manager-metrics-reader

--- a/config/rhoai/kustomization.yaml
+++ b/config/rhoai/kustomization.yaml
@@ -47,6 +47,9 @@ resources:
 - batch-user-rolebinding.yaml
 - kueue-metrics-service.yaml
 - prometheus_rule.yaml
+- kueue_metrics_reader_serviceaccount.yaml
+- metrics_reader_clusterrole_binding.yaml
+- kueue_metrics_reader_secret.yaml
 
 patches:
 # Mount the controller config file for loading manager configurations
@@ -62,3 +65,25 @@ patches:
 - path: validating_webhook_patch.yaml
 - path: clusterqueue_viewer_role_patch.yaml
 - path: remove_default_namespace.yaml
+
+replacements:
+  - source:
+      kind: ServiceAccount
+      name: controller-manager-metrics-reader
+      fieldPath: metadata.name
+    targets:
+      - select:
+          kind: Secret
+          name: controller-manager-metrics-token
+        fieldPaths:
+          - metadata.annotations.[kubernetes.io/service-account.name]
+  - source:
+      kind: Secret
+      name: controller-manager-metrics-token
+      fieldPath: metadata.name
+    targets:
+      - select:
+          kind: ServiceMonitor
+          name: controller-manager-metrics-monitor
+        fieldPaths:
+          - spec.endpoints.0.authorization.credentials.name

--- a/config/rhoai/metrics_reader_clusterrole_binding.yaml
+++ b/config/rhoai/metrics_reader_clusterrole_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: controller-manager-read-metrics
+subjects:
+- kind: ServiceAccount
+  name: controller-manager-metrics-reader  # Change this to your Prometheus service account
+  namespace: system
+roleRef:
+  kind: ClusterRole
+  name: metrics-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/config/rhoai/monitor.yaml
+++ b/config/rhoai/monitor.yaml
@@ -1,4 +1,4 @@
-# Prometheus Pod Monitor (Metrics)
+# Prometheus Service Monitor (Metrics)
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -10,8 +10,13 @@ spec:
       app.kubernetes.io/name: kueue
       app.kubernetes.io/component: controller
   endpoints:
-  - port: https-metrics
+  - authorization:
+      credentials:
+        key: token
+        name: controller-manager-metrics-token
+      type: Bearer
+    path: /metrics
+    port: https-metrics
     scheme: https
     tlsConfig:
       insecureSkipVerify: true
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHOAIENG-19954 

## Changes:
- Using `authorization` in ServiceMonitor as `bearerTokenFile` is deprecated.
- Created a Kueue metrics reader `ServiceAccount` and a `Secret` associated to it.
- Created a `ClusterRoleBinding` to allow the `ServiceAccount` to read from the `/metrics` path, and enable it to scrape metrics.

## Verification steps:
Image built using the [Dockerfile.konflux file](https://github.com/red-hat-data-services/kueue/blob/main/Dockerfile.konflux): `quay.io/rh_ee_czaccari/kueue:v0.10.1-odh-2-2-g0d44b3c41-dirty`

1. change in params.env file to: odh-kueue-controller-image=quay.io/rh_ee_czaccari/kueue:v0.10.1-odh-2-2-g0d44b3c41-dirty
2. change in makefile, deploy AND undeploy targets to use config/rhoai.
3. Change in conig/rhoai/kustomization.yaml file namespace to `redhat-ods-applications`
4. Run `make deploy IMAGE_REGISTRY=quay.io/rh_ee_czaccari GIT_TAG=v0.10.1-odh-2-2-g0d44b3c41-dirty`
5. See Kueue target is up.

