### PR TITLE
Upgrade Kueue to v0.11.6

### DIFF
--- a/config/component_metadata.yaml
+++ b/config/component_metadata.yaml
@@ -1,4 +1,4 @@
 releases:
   - name: kueue
-    version: 0.8.3
+    version: 0.11.6
     repoUrl: https://github.com/kubernetes-sigs/kueue

--- a/config/rhoai/params.env
+++ b/config/rhoai/params.env
@@ -1,1 +1,1 @@
-odh-kueue-controller-image=gcr.io/k8s-staging-kueue/kueue:main
+odh-kueue-controller-image=registry.k8s.io/kueue/kueue:v0.11.6


### PR DESCRIPTION
The upgrade has been pushed to this branch: https://github.com/opendatahub-io/kueue/tree/upgrade-0.11.6 

Performed this upgrade by following our guide: https://docs.google.com/document/d/1E22jx8y0DdPDoa_LAkWZQVmyRFKy10C0Kho6MAyHst4/edit?tab=t.0 