### PR TITLE
feat(RHOAIENG-63120) - Add operator-chaos integration and validation workflows

### DIFF
--- a/.github/workflows/chaos-validate.yml
+++ b/.github/workflows/chaos-validate.yml
@@ -1,0 +1,161 @@
+name: Chaos Validation
+
+on:
+  pull_request:
+    paths:
+      - "apis/**"
+      - "pkg/controller/**"
+      - "pkg/webhooks/**"
+      - "config/components/crd/**"
+      - "config/rhoai/**"
+      - "chaos/**"
+      - ".github/workflows/chaos-validate.yml"
+  workflow_dispatch:
+
+jobs:
+  chaos-validate:
+    name: Operator Chaos Validation
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      OPERATOR_CHAOS_VERSION: "9e6ac9668b9aaca2f0f2ddf169867862b7925b80"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install operator-chaos
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/bin"
+          GOBIN="${RUNNER_TEMP}/bin" go install "github.com/opendatahub-io/operator-chaos/cmd/operator-chaos@${OPERATOR_CHAOS_VERSION}"
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
+
+      - name: Checkout base branch assets
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: base-branch
+          persist-credentials: false
+          sparse-checkout: |
+            chaos/knowledge
+            chaos/experiments
+            config/components/crd/bases
+          sparse-checkout-cone-mode: false
+
+      - name: Validate knowledge model
+        shell: bash
+        run: |
+          set -euo pipefail
+          operator-chaos validate --knowledge "chaos/knowledge/kueue.yaml"
+
+      - name: Run local preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+          operator-chaos preflight --knowledge "chaos/knowledge/kueue.yaml" --local
+
+      - name: Validate chaos experiments
+        shell: bash
+        run: |
+          set -euo pipefail
+          status=0
+          shopt -s nullglob
+          for f in chaos/experiments/*.yaml; do
+            echo "--- ${f} ---"
+            if ! operator-chaos validate "${f}"; then
+              status=1
+            fi
+          done
+          exit "${status}"
+
+      - name: Diff knowledge model
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_knowledge_file="base-branch/chaos/knowledge/kueue.yaml"
+          if [[ ! -f "${base_knowledge_file}" ]]; then
+            echo "No base knowledge model found; skipping knowledge diff for bootstrap PR."
+            exit 0
+          fi
+
+          output_dir="${RUNNER_TEMP}/operator-chaos"
+          mkdir -p "${output_dir}"
+          knowledge_diff_json="${output_dir}/knowledge-diff.json"
+
+          operator-chaos diff \
+            --source "base-branch/chaos/knowledge" \
+            --target "chaos/knowledge" \
+            --breaking \
+            --format json > "${knowledge_diff_json}" || true
+          operator-chaos diff \
+            --source "base-branch/chaos/knowledge" \
+            --target "chaos/knowledge" \
+            --breaking || true
+
+          knowledge_breaking=$(jq -r '.summary.breakingChanges // 0' "${knowledge_diff_json}")
+          if (( knowledge_breaking > 0 )); then
+            echo "operator-chaos detected ${knowledge_breaking} breaking knowledge change(s)."
+            exit 1
+          fi
+
+      - name: Diff Kueue CRD schemas
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_crd_dir="base-branch/config/components/crd/bases"
+          target_crd_dir="config/components/crd/bases"
+          if [[ ! -d "${source_crd_dir}" || ! -d "${target_crd_dir}" ]]; then
+            echo "Base or current Kueue CRD directory not found; skipping CRD diff for bootstrap PR."
+            exit 0
+          fi
+
+          output_dir="${RUNNER_TEMP}/operator-chaos"
+          mkdir -p "${output_dir}"
+          source_dir="${output_dir}/source-crds"
+          target_dir="${output_dir}/target-crds"
+          crd_diff_json="${output_dir}/crd-diff.json"
+          rm -rf "${source_dir}" "${target_dir}"
+          mkdir -p "${source_dir}" "${target_dir}"
+          cp "${source_crd_dir}"/*.yaml "${source_dir}/"
+          cp "${target_crd_dir}"/*.yaml "${target_dir}/"
+
+          operator-chaos diff-crds \
+            --source-crds "${source_dir}" \
+            --target-crds "${target_dir}" \
+            --format json > "${crd_diff_json}" || true
+          operator-chaos diff-crds \
+            --source-crds "${source_dir}" \
+            --target-crds "${target_dir}" || true
+
+          crd_breaking=$(jq -r '
+            reduce ((.crds // [])[]?.apiVersions[]?.schemaChanges[]?) as $change
+              (0; if ($change.severity | ascii_downcase) == "breaking" then . + 1 else . end)
+          ' "${crd_diff_json}")
+          if (( crd_breaking > 0 )); then
+            echo "operator-chaos detected ${crd_breaking} breaking CRD schema change(s)."
+            exit 1
+          fi
+
+      - name: Preview upgrade simulation
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_knowledge_file="base-branch/chaos/knowledge/kueue.yaml"
+          if [[ ! -f "${base_knowledge_file}" ]]; then
+            echo "No base knowledge model found; skipping simulate-upgrade for bootstrap PR."
+            exit 0
+          fi
+
+          operator-chaos simulate-upgrade \
+            --source "base-branch/chaos/knowledge" \
+            --target "chaos/knowledge" \
+            --dry-run

--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,5 @@ testbin/*
 # Directory with CRDs for dependencies
 dep-crds
 
-kueue.yaml
+# Generated manifest at repo root (do not ignore chaos/knowledge/kueue.yaml)
+/kueue.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+# Agent guidance for Kueue
+
+## Operator-chaos shift-left validation (L2)
+
+This repository integrates [operator-chaos](https://github.com/opendatahub-io/operator-chaos) at **maturity level L2**:
+
+- **L1**: GitHub Actions workflow runs breaking-change detection on PRs that touch APIs, controllers, CRDs, or chaos assets.
+- **L2**: A repo-local knowledge model and chaos experiment YAMLs validate upgrade state transitions via `simulate-upgrade --dry-run`.
+
+### Local validation
+
+Install the pinned CLI and validate offline:
+
+```bash
+make chaos-validate
+```
+
+This runs:
+
+1. `operator-chaos validate --knowledge chaos/knowledge/kueue.yaml`
+2. `operator-chaos preflight --knowledge chaos/knowledge/kueue.yaml --local`
+3. `operator-chaos validate` for each file in `chaos/experiments/`
+
+### CI workflow
+
+The workflow at `.github/workflows/chaos-validate.yml` runs on PRs that modify:
+
+- `apis/**`
+- `pkg/controller/**`
+- `pkg/webhooks/**`
+- `config/components/crd/**`
+- `config/rhoai/**`
+- `chaos/**`
+
+It validates the knowledge model, diffs knowledge and CRD schemas against the PR base, validates experiment YAMLs, and previews upgrade simulation with `--dry-run`. Breaking knowledge or CRD changes fail the check.
+
+### Maintenance expectations
+
+Update `chaos/knowledge/kueue.yaml` when any of the following change:
+
+- RHOAI deployment topology in `config/rhoai/` (resource names, namespace, webhooks)
+- Controller-managed resources or steady-state health signals
+- Admission webhook names or paths in `config/components/webhook/manifests.yaml`
+
+Update or add experiments in `chaos/experiments/` when new upgrade-relevant failure modes should be covered (for example config drift, webhook disruption, or CRD mutation during upgrades).
+
+Regenerate CRDs with `make manifests` after API type changes under `apis/`.
+
+### Future maturity (not yet adopted)
+
+- **L3**: ChaosClient SDK tests in envtest/integration suites
+- **L4**: Upgrade playbook YAML and OLM channel-hop simulation
+
+See the operator-chaos repository for experiment authoring and CLI reference.

--- a/Makefile
+++ b/Makefile
@@ -406,3 +406,23 @@ ray-project-mini-image-build:
 kind-ray-project-mini-image-build: PLATFORMS=linux/amd64
 kind-ray-project-mini-image-build: PUSH=--load
 kind-ray-project-mini-image-build: ray-project-mini-image-build
+
+##@ Operator Chaos
+
+OPERATOR_CHAOS_VERSION ?= 9e6ac9668b9aaca2f0f2ddf169867862b7925b80
+OPERATOR_CHAOS ?= $(BIN_DIR)/operator-chaos
+
+.PHONY: operator-chaos
+operator-chaos: ## Download operator-chaos locally if necessary.
+	test -s "$(OPERATOR_CHAOS)" || GOBIN="$(BIN_DIR)" $(GO_CMD) install github.com/opendatahub-io/operator-chaos/cmd/operator-chaos@$(OPERATOR_CHAOS_VERSION)
+
+.PHONY: chaos-validate
+chaos-validate: operator-chaos ## Validate knowledge model and chaos experiments offline.
+	$(OPERATOR_CHAOS) validate --knowledge chaos/knowledge/kueue.yaml
+	$(OPERATOR_CHAOS) preflight --knowledge chaos/knowledge/kueue.yaml --local
+	@status=0; \
+	for f in chaos/experiments/*.yaml; do \
+		echo "--- $$f ---"; \
+		$(OPERATOR_CHAOS) validate "$$f" || status=1; \
+	done; \
+	exit $$status

--- a/chaos/experiments/clusterqueue-crd-mutation.yaml
+++ b/chaos/experiments/clusterqueue-crd-mutation.yaml
@@ -1,0 +1,43 @@
+# IMPORTANT: Replace "test-clusterqueue" with the name of an actual ClusterQueue
+# resource deployed in the target cluster before running this experiment live.
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: kueue-clusterqueue-crd-mutation
+spec:
+  tier: 3
+  target:
+    operator: kueue
+    component: kueue-controller-manager
+    resource: ClusterQueue
+  steadyState:
+    checks:
+      - type: conditionTrue
+        apiVersion: apps/v1
+        kind: Deployment
+        name: kueue-controller-manager
+        namespace: opendatahub
+        conditionType: Available
+    timeout: "30s"
+  injection:
+    type: CRDMutation
+    dangerLevel: high
+    parameters:
+      apiVersion: kueue.x-k8s.io/v1beta1
+      kind: ClusterQueue
+      name: test-clusterqueue
+      field: chaosTest
+      value: injected
+    ttl: "300s"
+  hypothesis:
+    description: >-
+      When a ClusterQueue CR is mutated with an unknown field via merge patch,
+      the controller should reconcile without error and not propagate the
+      unknown field to downstream scheduling state. The chaos framework removes
+      the injected field via TTL-based cleanup after 300s.
+    recoveryTimeout: 120s
+  blastRadius:
+    maxPodsAffected: 1
+    allowDangerous: true
+    allowedNamespaces:
+      - opendatahub

--- a/chaos/experiments/config-drift.yaml
+++ b/chaos/experiments/config-drift.yaml
@@ -1,0 +1,38 @@
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: kueue-config-drift
+spec:
+  tier: 2
+  target:
+    operator: kueue
+    component: kueue-controller-manager
+    resource: ConfigMap/kueue-manager-config
+  steadyState:
+    checks:
+      - type: resourceExists
+        apiVersion: v1
+        kind: ConfigMap
+        name: kueue-manager-config
+        namespace: opendatahub
+    timeout: "30s"
+  injection:
+    type: ConfigDrift
+    dangerLevel: high
+    parameters:
+      name: kueue-manager-config
+      key: chaos-injected
+      value: '{"corrupted":"by-chaos"}'
+      resourceType: ConfigMap
+    ttl: "300s"
+  hypothesis:
+    description: >-
+      When the kueue-manager-config ConfigMap is corrupted, the controller
+      should continue operating with its mounted configuration. The chaos
+      framework restores the injected key via TTL-based cleanup.
+    recoveryTimeout: 180s
+  blastRadius:
+    maxPodsAffected: 1
+    allowDangerous: true
+    allowedNamespaces:
+      - opendatahub

--- a/chaos/experiments/controller-pod-kill.yaml
+++ b/chaos/experiments/controller-pod-kill.yaml
@@ -1,0 +1,36 @@
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: kueue-controller-pod-kill
+spec:
+  tier: 1
+  target:
+    operator: kueue
+    component: kueue-controller-manager
+    resource: Deployment/kueue-controller-manager
+  steadyState:
+    checks:
+      - type: conditionTrue
+        apiVersion: apps/v1
+        kind: Deployment
+        name: kueue-controller-manager
+        namespace: opendatahub
+        conditionType: Available
+    timeout: "30s"
+  injection:
+    type: PodKill
+    parameters:
+      labelSelector: app.kubernetes.io/name=kueue,app.kubernetes.io/component=controller
+    count: 1
+    ttl: "300s"
+  hypothesis:
+    description: >-
+      When the kueue-controller-manager pod is killed, pending workloads
+      should queue but not be admitted during downtime. Kubernetes should
+      recreate the pod, and the controller should recover and resume
+      scheduling within the recovery timeout.
+    recoveryTimeout: 120s
+  blastRadius:
+    maxPodsAffected: 1
+    allowedNamespaces:
+      - opendatahub

--- a/chaos/experiments/network-partition.yaml
+++ b/chaos/experiments/network-partition.yaml
@@ -1,0 +1,35 @@
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: kueue-network-partition
+spec:
+  tier: 2
+  target:
+    operator: kueue
+    component: kueue-controller-manager
+    resource: Deployment/kueue-controller-manager
+  steadyState:
+    checks:
+      - type: conditionTrue
+        apiVersion: apps/v1
+        kind: Deployment
+        name: kueue-controller-manager
+        namespace: opendatahub
+        conditionType: Available
+    timeout: "30s"
+  injection:
+    type: NetworkPartition
+    parameters:
+      labelSelector: app.kubernetes.io/name=kueue,app.kubernetes.io/component=controller
+    ttl: "300s"
+  hypothesis:
+    description: >-
+      When kueue-controller-manager pods are network-partitioned from the API
+      server, workload admission stops and no new workloads are scheduled.
+      Existing admitted workloads continue running. Once the partition is
+      removed, scheduling resumes without manual intervention.
+    recoveryTimeout: 180s
+  blastRadius:
+    maxPodsAffected: 1
+    allowedNamespaces:
+      - opendatahub

--- a/chaos/experiments/webhook-disrupt.yaml
+++ b/chaos/experiments/webhook-disrupt.yaml
@@ -1,0 +1,40 @@
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: kueue-webhook-disrupt
+spec:
+  tier: 4
+  target:
+    operator: kueue
+    component: kueue-controller-manager
+    resource: ValidatingWebhookConfiguration/vclusterqueue.kb.io
+  steadyState:
+    checks:
+      - type: conditionTrue
+        apiVersion: apps/v1
+        kind: Deployment
+        name: kueue-controller-manager
+        namespace: opendatahub
+        conditionType: Available
+    timeout: "30s"
+  injection:
+    type: WebhookDisrupt
+    dangerLevel: high
+    parameters:
+      webhookName: vclusterqueue.kb.io
+      action: setFailurePolicy
+      value: Ignore
+    ttl: "60s"
+  hypothesis:
+    description: >-
+      When the ClusterQueue validating webhook failurePolicy is weakened from
+      Fail to Ignore, invalid ClusterQueue specs can bypass admission
+      validation. The controller should handle invalid resources gracefully.
+      The chaos framework restores the original failurePolicy via TTL-based
+      cleanup after 60s.
+    recoveryTimeout: 120s
+  blastRadius:
+    maxPodsAffected: 1
+    allowDangerous: true
+    allowedNamespaces:
+      - opendatahub

--- a/chaos/knowledge/kueue.yaml
+++ b/chaos/knowledge/kueue.yaml
@@ -1,0 +1,107 @@
+operator:
+  name: kueue
+  namespace: opendatahub
+  repository: https://github.com/opendatahub-io/kueue
+
+components:
+  - name: kueue-controller-manager
+    controller: KueueControllerManager
+    managedResources:
+      - apiVersion: apps/v1
+        kind: Deployment
+        name: kueue-controller-manager
+        namespace: opendatahub
+        labels:
+          app.kubernetes.io/name: kueue
+          app.kubernetes.io/component: controller
+        expectedSpec:
+          replicas: 1
+      - apiVersion: v1
+        kind: ServiceAccount
+        name: kueue-controller-manager
+        namespace: opendatahub
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        name: kueue-manager-role
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        name: kueue-manager-rolebinding
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        name: kueue-metrics-auth-role
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        name: kueue-metrics-auth-rolebinding
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        name: kueue-metrics-reader
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: Role
+        name: kueue-leader-election-role
+        namespace: opendatahub
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        name: kueue-leader-election-rolebinding
+        namespace: opendatahub
+      - apiVersion: v1
+        kind: Service
+        name: kueue-webhook-service
+        namespace: opendatahub
+      - apiVersion: v1
+        kind: Service
+        name: kueue-metrics-service
+        namespace: opendatahub
+      - apiVersion: v1
+        kind: ConfigMap
+        name: kueue-manager-config
+        namespace: opendatahub
+      - apiVersion: v1
+        kind: Secret
+        name: kueue-webhook-server-cert
+        namespace: opendatahub
+      - apiVersion: coordination.k8s.io/v1
+        kind: Lease
+        name: c1f6bfd2.kueue.x-k8s.io
+        namespace: opendatahub
+      - apiVersion: monitoring.coreos.com/v1
+        kind: ServiceMonitor
+        name: kueue-controller-manager-metrics-monitor
+        namespace: opendatahub
+    webhooks:
+      - name: vworkload.kb.io
+        type: validating
+        path: /validate-kueue-x-k8s-io-v1beta1-workload
+      - name: vclusterqueue.kb.io
+        type: validating
+        path: /validate-kueue-x-k8s-io-v1beta1-clusterqueue
+      - name: vlocalqueue.kb.io
+        type: validating
+        path: /validate-kueue-x-k8s-io-v1beta1-localqueue
+      - name: vresourceflavor.kb.io
+        type: validating
+        path: /validate-kueue-x-k8s-io-v1beta1-resourceflavor
+      - name: vcohort.kb.io
+        type: validating
+        path: /validate-kueue-x-k8s-io-v1alpha1-cohort
+      - name: mworkload.kb.io
+        type: mutating
+        path: /mutate-kueue-x-k8s-io-v1beta1-workload
+      - name: mclusterqueue.kb.io
+        type: mutating
+        path: /mutate-kueue-x-k8s-io-v1beta1-clusterqueue
+      - name: mresourceflavor.kb.io
+        type: mutating
+        path: /mutate-kueue-x-k8s-io-v1beta1-resourceflavor
+    steadyState:
+      checks:
+        - type: conditionTrue
+          apiVersion: apps/v1
+          kind: Deployment
+          name: kueue-controller-manager
+          namespace: opendatahub
+          conditionType: Available
+      timeout: "60s"
+
+recovery:
+  reconcileTimeout: "300s"
+  maxReconcileCycles: 10


### PR DESCRIPTION
- Introduced `AGENTS.md` for agent guidance on operator-chaos integration at maturity level L2.
- Updated `Makefile` to include commands for downloading and validating operator-chaos locally.
- Created GitHub Actions workflow `.github/workflows/chaos-validate.yml` to automate chaos validation on PRs affecting specific paths.
- Added multiple chaos experiment YAML files in `chaos/experiments/` to cover various failure modes, including CRD mutation, config drift, pod kill, network partition, and webhook disruption.

This commit enhances the repository's ability to validate chaos experiments and maintain upgrade stability through automated checks.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
[RHOAIENG-63120](https://redhat.atlassian.net/browse/RHOAIENG-63120)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added chaos validation framework with multiple experiment scenarios for enhanced system resilience testing.

* **Documentation**
  * Added comprehensive guide for chaos validation practices and maturity levels.

* **Chores**
  * Enhanced CI/CD pipeline with automated validation checks.
  * Added build tooling for local chaos validation execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->